### PR TITLE
First-class ArrayExpression support

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -4,7 +4,7 @@ exports[`babel-plugin-transform-object-literals 1. babel-plugin-transform-object
 "
 const json = {
       items: {
-        name: 'Sun',
+        name: \\"Sun\\",
         where: 'Solar sytem',
       },
     }

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -8,7 +8,7 @@ pluginTester({
   tests: [
     `const json = {
       items: {
-        name: 'Sun',
+        name: "Sun",
         where: 'Solar sytem',
       },
     }`,
@@ -22,5 +22,7 @@ pluginTester({
     `const json = {
       items: [1,2,3]
     }`,
+    ,
+    `const json = [1, '1', 'a']`,
   ],
 })


### PR DESCRIPTION
This RP allows the following expression:

```js
const data = ['a', 'b', 1]
```